### PR TITLE
add select2 tags input

### DIFF
--- a/app/assets/javascripts/active_admin/select2/select2.js.coffee
+++ b/app/assets/javascripts/active_admin/select2/select2.js.coffee
@@ -1,7 +1,17 @@
-$(document).on 'has_many_add:after', '.has_many_container', (e, fieldset) ->
-  fieldset.find('.select2-input').select2({allowClear: true }) 
+'use strict';
 
+initSelect2 = (inputs, extra = {}) ->
+  inputs.each ->
+    item = $(this)
+    # reading from data allows <input data-select2='{"tags": ['some']}'> to be passed to select2
+    options = $.extend(allowClear: true, extra, item.data('select2'))
+    # because select2 reads from input.data to check if it is select2 already
+    item.data('select2', null)
+    item.select2(options)
+
+$(document).on 'has_many_add:after', '.has_many_container', (e, fieldset) ->
+  initSelect2(fieldset.find('.select2-input'))
 
 $(document).ready ->
-  $(".select2-input").select2 placeholder: "", allowClear: true
+  initSelect2($(".select2-input"), placeholder: "")
   return

--- a/lib/activeadmin-select2.rb
+++ b/lib/activeadmin-select2.rb
@@ -3,4 +3,5 @@ require 'activeadmin/select2'
 require 'activeadmin/inputs/filter_select2_multiple_input'
 require 'formtastic/inputs/select2_input'
 require 'formtastic/inputs/select2_multiple_input'
+require 'formtastic/inputs/select2_tags_input'
 

--- a/lib/formtastic/inputs/select2_tags_input.rb
+++ b/lib/formtastic/inputs/select2_tags_input.rb
@@ -1,0 +1,16 @@
+require 'formtastic/inputs/string_input'
+
+module Formtastic
+  module Inputs
+
+    class Select2TagsInput < Formtastic::Inputs::StringInput
+      def input_html_options
+        {
+            class: 'select2-input select2-tags-input',
+            data: { select2: { tags: options[:collection] }}
+        }.merge(super)
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
this PR adds tags input

you can use it as 

``` ruby
f.input :tag_list, as: :select2_tags, collection: f.object.class.tag_counts.map(&:name)
```

also refactors the js so you can pass options to select2 in data attributes
