### PR TITLE
Jquery 3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .ruby-version
 .ruby-gemset
+.idea
 Gemfile.lock
 /pkg/*

--- a/app/assets/javascripts/active_admin/select2/select2.js.coffee
+++ b/app/assets/javascripts/active_admin/select2/select2.js.coffee
@@ -8,7 +8,6 @@ initSelect2 = (inputs, extra = {}) ->
     # because select2 reads from input.data to check if it is select2 already
     item.data('select2', null)
     item.select2(options)
-    $(".select2-container", item.parent()).removeAttr("style")
 
 $(document).on 'has_many_add:after', '.has_many_container', (e, fieldset) ->
   initSelect2(fieldset.find('.select2-input'))

--- a/app/assets/javascripts/active_admin/select2/select2.js.coffee
+++ b/app/assets/javascripts/active_admin/select2/select2.js.coffee
@@ -8,10 +8,15 @@ initSelect2 = (inputs, extra = {}) ->
     # because select2 reads from input.data to check if it is select2 already
     item.data('select2', null)
     item.select2(options)
+    $(".select2-container", item.parent()).removeAttr("style")
 
 $(document).on 'has_many_add:after', '.has_many_container', (e, fieldset) ->
   initSelect2(fieldset.find('.select2-input'))
 
-$(document).on 'ready page:load turbolinks:load', ->
+$(document).on 'page:load turbolinks:load', ->
   initSelect2($(".select2-input"), placeholder: "")
+  return
+
+$ ->
+  initSelect2($(".select2-input"), placeholder: "", width: "style")
   return

--- a/lib/activeadmin/select2/version.rb
+++ b/lib/activeadmin/select2/version.rb
@@ -1,5 +1,5 @@
 module ActiveAdmin
   module Select2
-    VERSION = "0.1.8"
+    VERSION = "0.1.9"
   end
 end


### PR DESCRIPTION
jQuery dropped support for `on("ready")` in version 3.0, so PR involves separating that out into the only way that will be supported for jQuery 4.0 (namely: `$(handler)`).  This also caters for `select2` now trying by default to size the input to the same size as the underlying input.  Adding `width: style` keeps old behavior)