### PR TITLE
updates to jQuery3 standards

### DIFF
--- a/app/assets/javascripts/active_admin/select2/select2.js.coffee
+++ b/app/assets/javascripts/active_admin/select2/select2.js.coffee
@@ -12,6 +12,10 @@ initSelect2 = (inputs, extra = {}) ->
 $(document).on 'has_many_add:after', '.has_many_container', (e, fieldset) ->
   initSelect2(fieldset.find('.select2-input'))
 
-$(document).on 'ready page:load turbolinks:load', ->
+$(document).on 'page:load turbolinks:load', ->
+  initSelect2($(".select2-input"), placeholder: "")
+  return
+
+$(document).ready ->
   initSelect2($(".select2-input"), placeholder: "")
   return


### PR DESCRIPTION
`$(document).on('ready')` was removed and replaced with `$(document).ready()`